### PR TITLE
add TaxiTaskBaseType enum; make TaxiTaskType extendable

### DIFF
--- a/src/main/java/org/matsim/pfav/privateAV/FreightTourDispatchAnalyzer.java
+++ b/src/main/java/org/matsim/pfav/privateAV/FreightTourDispatchAnalyzer.java
@@ -40,7 +40,7 @@ import org.matsim.contrib.dvrp.fleet.Fleet;
 import org.matsim.contrib.dvrp.router.DvrpGlobalRoutingNetworkProvider;
 import org.matsim.contrib.dvrp.run.QSimScopeObjectListener;
 import org.matsim.contrib.dvrp.schedule.Task;
-import org.matsim.contrib.taxi.schedule.TaxiTaskType;
+import org.matsim.contrib.taxi.schedule.TaxiTaskBaseType;
 import org.matsim.contrib.util.CSVLineBuilder;
 import org.matsim.contrib.util.CompactCSVWriter;
 import org.matsim.core.controler.events.IterationEndsEvent;
@@ -104,9 +104,9 @@ class FreightTourDispatchAnalyzer implements FreightTourRequestEventHandler, QSi
             data.addToActualTourLength(link.getLength());
 
             Task t = (fleet.getVehicles().get(event.getVehicleId())).getSchedule().getCurrentTask();
-            if (t.getTaskType().equals(TaxiTaskType.EMPTY_DRIVE)) {
-                data.addToActualEmptyMeters(link.getLength());
-            }
+			if (TaxiTaskBaseType.EMPTY_DRIVE.isBaseTypeOf(t)) {
+				data.addToActualEmptyMeters(link.getLength());
+			}
         }
     }
 

--- a/src/main/java/org/matsim/pfav/privateAV/PFAVActionCreator.java
+++ b/src/main/java/org/matsim/pfav/privateAV/PFAVActionCreator.java
@@ -35,7 +35,7 @@ import org.matsim.contrib.taxi.run.TaxiConfigGroup;
 import org.matsim.contrib.taxi.schedule.TaxiDropoffTask;
 import org.matsim.contrib.taxi.schedule.TaxiPickupTask;
 import org.matsim.contrib.taxi.schedule.TaxiStayTask;
-import org.matsim.contrib.taxi.schedule.TaxiTaskType;
+import org.matsim.contrib.taxi.schedule.TaxiTaskBaseType;
 import org.matsim.core.mobsim.framework.MobsimTimer;
 
 /**
@@ -72,7 +72,7 @@ public final class PFAVActionCreator implements VrpAgentLogic.DynActionCreator {
 	@Override
 	public DynAction createAction(DynAgent dynAgent, DvrpVehicle vehicle, double now) {
 		Task task = vehicle.getSchedule().getCurrentTask();
-		switch ((TaxiTaskType)task.getTaskType()) {
+		switch (TaxiTaskBaseType.getBaseType(task)) {
 			case EMPTY_DRIVE:
 			case OCCUPIED_DRIVE:
 				return legFactory.create(vehicle);

--- a/src/main/java/org/matsim/pfav/privateAV/PFAVRetoolTask.java
+++ b/src/main/java/org/matsim/pfav/privateAV/PFAVRetoolTask.java
@@ -22,7 +22,7 @@ import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.schedule.StayTask;
-import org.matsim.contrib.taxi.schedule.TaxiTaskType;
+import org.matsim.contrib.taxi.schedule.TaxiDropoffTask;
 
 /**
  * @author tschlenther
@@ -44,7 +44,7 @@ class PFAVRetoolTask extends StayTask {
 		 * but pickup task type is somehow used for TaxiStatsCalculator in correspondence with a request (which we do not have here, so we use dropoff type.
 		 * furthermore, if it was of type stay, the task could be removed by the taxischeduler if there is delay in the schedule
 		 */
-		super(TaxiTaskType.DROPOFF, beginTime, endTime, link);
+		super(TaxiDropoffTask.TYPE, beginTime, endTime, link);
 	}
 	
 	/**

--- a/src/main/java/org/matsim/pfav/privateAV/PFAVScheduler.java
+++ b/src/main/java/org/matsim/pfav/privateAV/PFAVScheduler.java
@@ -32,14 +32,12 @@ import org.matsim.contrib.taxi.schedule.TaxiEmptyDriveTask;
 import org.matsim.contrib.taxi.schedule.TaxiOccupiedDriveTask;
 import org.matsim.contrib.taxi.schedule.TaxiPickupTask;
 import org.matsim.contrib.taxi.schedule.TaxiStayTask;
-import org.matsim.contrib.taxi.schedule.TaxiTaskType;
+import org.matsim.contrib.taxi.schedule.TaxiTaskBaseType;
 import org.matsim.contrib.taxi.scheduler.TaxiScheduleInquiry;
 import org.matsim.contrib.taxi.scheduler.TaxiScheduler;
 import org.matsim.core.api.experimental.events.EventsManager;
 import org.matsim.core.mobsim.framework.MobsimTimer;
-import org.matsim.core.router.FastAStarEuclideanFactory;
 import org.matsim.core.router.util.LeastCostPathCalculator;
-import org.matsim.core.router.util.TravelDisutility;
 import org.matsim.core.router.util.TravelTime;
 
 import com.google.inject.name.Named;
@@ -89,7 +87,7 @@ final class PFAVScheduler implements TaxiScheduleInquiry {
 		updateTimeline(vehicle);
 		Task currentTask = schedule.getCurrentTask();
 
-		switch ((TaxiTaskType)currentTask.getTaskType()) {
+		switch (TaxiTaskBaseType.getBaseType(currentTask)) {
 			case PICKUP:
 				if (!taxiCfg.isDestinationKnown()) {
 					appendResultingTasksAfterPickup(vehicle);
@@ -370,7 +368,7 @@ final class PFAVScheduler implements TaxiScheduleInquiry {
 		Schedule schedule = vehicle.getSchedule();
 		Task lastTask = Schedules.getLastTask(schedule);
 
-		if (lastTask.getTaskType() != TaxiTaskType.STAY) {
+		if (!TaxiTaskBaseType.STAY.isBaseTypeOf(lastTask)) {
 			throw new IllegalStateException();
 		} else {
 
@@ -514,7 +512,7 @@ final class PFAVScheduler implements TaxiScheduleInquiry {
 	private final static double REMOVE_STAY_TASK = Double.NEGATIVE_INFINITY;
 
 	private double calcNewEndTime(DvrpVehicle vehicle, Task task, double newBeginTime) {
-		switch ((TaxiTaskType)task.getTaskType()) {
+		switch (TaxiTaskBaseType.getBaseType(task)) {
 			case STAY: {
 				if (Schedules.getLastTask(vehicle.getSchedule()).equals(task)) {// last task
 					// even if endTime=beginTime, do not remove this task!!! A taxi schedule should end with WAIT

--- a/src/main/java/org/matsim/pfav/privateAV/PFAVServiceDriveTask.java
+++ b/src/main/java/org/matsim/pfav/privateAV/PFAVServiceDriveTask.java
@@ -20,7 +20,7 @@ package org.matsim.pfav.privateAV;
 
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.schedule.DriveTask;
-import org.matsim.contrib.taxi.schedule.TaxiTaskType;
+import org.matsim.contrib.taxi.schedule.TaxiOccupiedDriveTask;
 
 /**
  * @author tschlenther
@@ -28,6 +28,6 @@ import org.matsim.contrib.taxi.schedule.TaxiTaskType;
  */
 class PFAVServiceDriveTask extends DriveTask {
     PFAVServiceDriveTask(VrpPathWithTravelData path) {
-		super(TaxiTaskType.OCCUPIED_DRIVE, path);
+		super(TaxiOccupiedDriveTask.TYPE, path);
 	}
 }

--- a/src/main/java/org/matsim/pfav/privateAV/PFAVServiceTask.java
+++ b/src/main/java/org/matsim/pfav/privateAV/PFAVServiceTask.java
@@ -21,7 +21,7 @@ package org.matsim.pfav.privateAV;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.dvrp.schedule.StayTask;
 import org.matsim.contrib.freight.carrier.CarrierService;
-import org.matsim.contrib.taxi.schedule.TaxiTaskType;
+import org.matsim.contrib.taxi.schedule.TaxiDropoffTask;
 
 /**
  * @author tschlenther
@@ -37,7 +37,7 @@ class PFAVServiceTask extends StayTask {
 	 * @param link
 	 */
     PFAVServiceTask(double beginTime, double endTime, Link link, CarrierService service) {
-		super(TaxiTaskType.DROPOFF, beginTime, endTime, link);
+		super(TaxiDropoffTask.TYPE, beginTime, endTime, link);
 		this.service = service;
 	}
 	


### PR DESCRIPTION
Adapt to introduction of base types in taxi.

As a potential follow-up:
I would consider not assigning the base type to some/all PFAV tasks in the future. Then these tasks would be handled by a separate logic (like the e-taxi charging task).

Probably refactoring (mainly splitting into smaller components) the default `TaxiScheduler` would also simplify `PFAVScheduler` (this was not so critical for e-taxi, but here the logic is much more different from the standard taxi).