### PR TITLE
define dedicated task types for PFAV tasks

### DIFF
--- a/src/main/java/org/matsim/pfav/privateAV/PFAVRetoolTask.java
+++ b/src/main/java/org/matsim/pfav/privateAV/PFAVRetoolTask.java
@@ -18,37 +18,40 @@
  * *********************************************************************** */
 package org.matsim.pfav.privateAV;
 
+import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.DROPOFF;
+
 import org.matsim.api.core.v01.Id;
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.dvrp.fleet.DvrpVehicle;
 import org.matsim.contrib.dvrp.schedule.StayTask;
-import org.matsim.contrib.taxi.schedule.TaxiDropoffTask;
+import org.matsim.contrib.taxi.schedule.TaxiTaskType;
 
 /**
  * @author tschlenther
- *
  */
 class PFAVRetoolTask extends StayTask {
+	public static final TaxiTaskType TYPE = new TaxiTaskType("RETOOL", DROPOFF);
 
 	double earliestStartTime = 0.0;
 	Id<DvrpVehicle> vehicle = null;
-	
+
 	/**
 	 * @param beginTime
 	 * @param endTime
 	 * @param link
 	 */
-    PFAVRetoolTask(double beginTime, double endTime, Link link) {
+	PFAVRetoolTask(double beginTime, double endTime, Link link) {
 		/*
 		 * we model this as a dropoff task, since retooling is closest to "picking a new car body up" or "dropping the old car body".
 		 * but pickup task type is somehow used for TaxiStatsCalculator in correspondence with a request (which we do not have here, so we use dropoff type.
 		 * furthermore, if it was of type stay, the task could be removed by the taxischeduler if there is delay in the schedule
 		 */
-		super(TaxiDropoffTask.TYPE, beginTime, endTime, link);
+		super(TYPE, beginTime, endTime, link);
 	}
-	
+
 	/**
 	 * if not set at some point, this will return 0.0
+	 *
 	 * @return
 	 */
 	double getEarliestStartTime() {
@@ -62,7 +65,7 @@ class PFAVRetoolTask extends StayTask {
 	void setVehicle(Id<DvrpVehicle> vehicle) {
 		this.vehicle = vehicle;
 	}
-	
+
 	@Override
 	public String toString() {
 		return super.toString() + " [" + this.getStatus() + "] " + "vehicle=" + this.vehicle;

--- a/src/main/java/org/matsim/pfav/privateAV/PFAVServiceDriveTask.java
+++ b/src/main/java/org/matsim/pfav/privateAV/PFAVServiceDriveTask.java
@@ -18,16 +18,19 @@
  * *********************************************************************** */
 package org.matsim.pfav.privateAV;
 
+import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.OCCUPIED_DRIVE;
+
 import org.matsim.contrib.dvrp.path.VrpPathWithTravelData;
 import org.matsim.contrib.dvrp.schedule.DriveTask;
-import org.matsim.contrib.taxi.schedule.TaxiOccupiedDriveTask;
+import org.matsim.contrib.taxi.schedule.TaxiTaskType;
 
 /**
  * @author tschlenther
- *
  */
 class PFAVServiceDriveTask extends DriveTask {
-    PFAVServiceDriveTask(VrpPathWithTravelData path) {
-		super(TaxiOccupiedDriveTask.TYPE, path);
+	public static final TaxiTaskType TYPE = new TaxiTaskType("SERVICE_DRIVE", OCCUPIED_DRIVE);
+
+	PFAVServiceDriveTask(VrpPathWithTravelData path) {
+		super(TYPE, path);
 	}
 }

--- a/src/main/java/org/matsim/pfav/privateAV/PFAVServiceTask.java
+++ b/src/main/java/org/matsim/pfav/privateAV/PFAVServiceTask.java
@@ -18,29 +18,31 @@
  * *********************************************************************** */
 package org.matsim.pfav.privateAV;
 
+import static org.matsim.contrib.taxi.schedule.TaxiTaskBaseType.DROPOFF;
+
 import org.matsim.api.core.v01.network.Link;
 import org.matsim.contrib.dvrp.schedule.StayTask;
 import org.matsim.contrib.freight.carrier.CarrierService;
-import org.matsim.contrib.taxi.schedule.TaxiDropoffTask;
+import org.matsim.contrib.taxi.schedule.TaxiTaskType;
 
 /**
  * @author tschlenther
- *
  */
 class PFAVServiceTask extends StayTask {
+	public static final TaxiTaskType TYPE = new TaxiTaskType("SERVICE", DROPOFF);
 
 	CarrierService service;
-	
+
 	/**
 	 * @param beginTime
 	 * @param endTime
 	 * @param link
 	 */
-    PFAVServiceTask(double beginTime, double endTime, Link link, CarrierService service) {
-		super(TaxiDropoffTask.TYPE, beginTime, endTime, link);
+	PFAVServiceTask(double beginTime, double endTime, Link link, CarrierService service) {
+		super(TYPE, beginTime, endTime, link);
 		this.service = service;
 	}
-	
+
 	CarrierService getCarrierService() {
 		return this.service;
 	}


### PR DESCRIPTION
Something I have forgotten to do: specifying a separate task types: `RETOOL`, `SERVICE` and `SERVICE_DRIVE`. Now we have stats and plots with a more fine-grained task categorisation. Like in this one here:
![0 taxi_status_time_profiles_taxi_StackedArea](https://user-images.githubusercontent.com/9891415/86890020-f735a100-c0fc-11ea-9c94-03b16d23b5ba.png)
